### PR TITLE
Added documentation on registering our sample hook

### DIFF
--- a/batch_import/EXAMPLE.md
+++ b/batch_import/EXAMPLE.md
@@ -213,6 +213,55 @@ to be high-definition.
 
 This file we will pass to the video-import script in a later step.
 
+#### Using the Example Hook Service
+
+Camio has set up a demo hook service that you can use as a proof-of-concept for other labeling services. This hook service simply returns a random list
+of labels from the set [cat, dog, mouse, pasta, tortilla, monkey, cheeto, hippo, leviathan]. 
+
+The example hook server is sitting at http://104.198.98.243 on port 8080, and the path to the hook endpoint is `/tasks/batch-import-test`. You must also submit a query
+for the hook to be applied over, in this case the easiest query to give is  `"1==1"`, which means the hook will run on all events uploaded.
+
+Note that this script also depends on the `CAMIO_OAUTH_TOKEN` environment variable being set in order to authenticate it as your account.
+
+To register this hook to your account run the following in your shell
+
+```bash
+$ cd ~/examples/hooks # go to your examples directory, then to the hooks directory
+$ bash hook-register.sh "http://104.198.98.243:8080/tasks/batch-import-test" "1==1"
+Note: Unnecessary use of -X or --request, POST is already inferred.
+*   Trying 216.239.38.21...
+* Connected to camio.com (216.239.38.21) port 443 (#0)
+* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+* Server certificate: *.camio.com
+* Server certificate: DigiCert SHA2 Secure Server CA
+* Server certificate: DigiCert Global Root CA
+> POST /api/users/me/hooks HTTP/1.1
+> Host: camio.com
+> User-Agent: curl/7.49.1
+> Accept: */*
+> Content-Type: application/json
+> Authorization: token zTiruJf-zL6dPQSb-mzHrgzGuiY40d7G
+> Content-Length: 117
+>
+* upload completely sent off: 117 out of 117 bytes
+< HTTP/1.1 200 OK
+< Expires: Thu, 01 Jan 1970 00:00:00 GMT
+< Set-Cookie: JSESSIONID=ozJ7lu-l3KOxlcgOCKsvzA;Path=/
+< Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH
+< Content-Type: application/json; charset=UTF-8
+< X-Cloud-Trace-Context: 5fe0397617bfac498481b45a111fcfbb
+< Date: Sat, 27 May 2017 00:47:36 GMT
+< Server: Google Frontend
+< Content-Length: 176
+< Cache-Control: private
+<
+* Connection #0 to host camio.com left intact
+{"id":"ag1zfmNhbWlvbG9nZ2VychELEgRIb29rGICAyLf_1ZcLDA","type":"query_match","parsed_query":"1\u003d\u003d1","callback_url":"http://104.198.98.243:8080/tasks/batch-import-test"}
+```
+
+The output returned from this call will include the hook ID and some other information about the hook. If you see the output listed above it means the hook registered succesfully,
+and you should see random subsets of the labels listed above showing up in your bookmark of labels that is downloaded after a job is complete.
+
 
 ####  Running the video-importer Script
 

--- a/batch_import/EXAMPLE.md
+++ b/batch_import/EXAMPLE.md
@@ -216,10 +216,10 @@ This file we will pass to the video-import script in a later step.
 #### Using the Example Hook Service
 
 Camio has set up a demo hook service that you can use as a proof-of-concept for other labeling services. This hook service simply returns a random list
-of labels from the set [cat, dog, mouse, pasta, tortilla, monkey, cheeto, hippo, leviathan]. 
+of labels from the set [cat, dog, mouse, pasta, tortilla, monkey, hippo, leviathan]. 
 
-The example hook server is sitting at http://104.198.98.243 on port 8080, and the path to the hook endpoint is `/tasks/batch-import-test`. You must also submit a query
-for the hook to be applied over, in this case the easiest query to give is  `"1==1"`, which means the hook will run on all events uploaded.
+The example hook server is sitting at http://104.198.98.243 on port 8080, and the path to the hook endpoint is `/tasks/batch-import-test`. You must also submit a `parsed_query` 
+for the hook to be applied over, in this case the easiest `parsed_query` to give is  `"1==1"`, which means the hook will run on all events uploaded.
 
 Note that this script also depends on the `CAMIO_OAUTH_TOKEN` environment variable being set in order to authenticate it as your account.
 
@@ -227,36 +227,16 @@ To register this hook to your account run the following in your shell
 
 ```bash
 $ cd ~/examples/hooks # go to your examples directory, then to the hooks directory
-$ bash hook-register.sh "http://104.198.98.243:8080/tasks/batch-import-test" "1==1"
-Note: Unnecessary use of -X or --request, POST is already inferred.
-*   Trying 216.239.38.21...
-* Connected to camio.com (216.239.38.21) port 443 (#0)
-* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-* Server certificate: *.camio.com
-* Server certificate: DigiCert SHA2 Secure Server CA
-* Server certificate: DigiCert Global Root CA
-> POST /api/users/me/hooks HTTP/1.1
-> Host: camio.com
-> User-Agent: curl/7.49.1
-> Accept: */*
-> Content-Type: application/json
-> Authorization: token zTiruJf-zL6dPQSb-mzHrgzGuiY40d7G
-> Content-Length: 117
->
-* upload completely sent off: 117 out of 117 bytes
-< HTTP/1.1 200 OK
-< Expires: Thu, 01 Jan 1970 00:00:00 GMT
-< Set-Cookie: JSESSIONID=ozJ7lu-l3KOxlcgOCKsvzA;Path=/
-< Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH
-< Content-Type: application/json; charset=UTF-8
-< X-Cloud-Trace-Context: 5fe0397617bfac498481b45a111fcfbb
-< Date: Sat, 27 May 2017 00:47:36 GMT
-< Server: Google Frontend
-< Content-Length: 176
-< Cache-Control: private
-<
-* Connection #0 to host camio.com left intact
-{"id":"ag1zfmNhbWlvbG9nZ2VychELEgRIb29rGICAyLf_1ZcLDA","type":"query_match","parsed_query":"1\u003d\u003d1","callback_url":"http://104.198.98.243:8080/tasks/batch-import-test"}
+$ bash hook-register.sh http://104.198.98.243:8080/tasks/batch-import-test "1==1"
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   293  100   176  100   117    410    272 --:--:-- --:--:-- --:--:--   411
+{
+  "id": "ag1zfmNhbWlvbG9nZ2VychELEgRIb29rGICAyPfHoJsIDA",
+  "type": "query_match",
+  "parsed_query": "1==1",
+  "callback_url": "http://104.198.98.243:8080/tasks/batch-import-test"
+}
 ```
 
 The output returned from this call will include the hook ID and some other information about the hook. If you see the output listed above it means the hook registered succesfully,

--- a/hooks/hook-register.sh
+++ b/hooks/hook-register.sh
@@ -12,8 +12,7 @@ auth_token="$CAMIO_OAUTH_TOKEN"
 callback_url="$1"
 query="$2"
 
-curl -v \
-    -H "Content-Type: application/json" \
+curl -H "Content-Type: application/json" \
     -H "Authorization: token $auth_token" \
     -d '{"callback_url": "'"$callback_url"'", "type": "query_match", "parsed_query": "'"$query"'"}' \
-    -X POST https://camio.com/api/users/me/hooks
+    https://camio.com/api/users/me/hooks

--- a/hooks/hook-register.sh
+++ b/hooks/hook-register.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 
-usage="bash $0 auth_token callback_url parsed_query"
+usage="bash $0 callback_url parsed_query"
 
-if [ "$#" -lt 3 ]; then
+if [ "$#" -lt 2 ]; then
   echo "Usage: $usage"
   exit 1
 fi
 
-auth_token="$1"
-callback_url="$2"
-query="$3"
+auth_token="$CAMIO_OAUTH_TOKEN"
+callback_url="$1"
+query="$2"
 
 curl -v \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
Also changed around the hook-register function to use the
CAMIO_OAUTH_TOKEN environment variable instead of expecting it to be
passed in explicitely.