### PR TITLE
Upload Everything Utility - Check Upload Queue Length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ ENV/
 .process*
 
 .processes.shelve
+
+.idea/*

--- a/utils/upload_everything/upload_everything.py
+++ b/utils/upload_everything/upload_everything.py
@@ -15,7 +15,7 @@ limitations under the License.
 
 
 Execute with:
-python upload_everything.py --cameras_filename your_cameras_filename.csv --time_range_filename your_time_range_filename.csv --token your_access_token --device_ids camio_box_device_id_1 camio_box_device_id_1
+python upload_everything.py --cameras_filename your_cameras_filename.csv --time_range_filename your_time_range_filename.csv --token your_access_token --device_ids camio_box_device_id_1 camio_box_device_id_1 --max_wait_time 600
 
 See help with:
 python upload_everything.py --help
@@ -150,7 +150,7 @@ def process_user(user, cameras, time_ranges, token, wait_seconds, max_wait_time,
                     break
 
                 elif not dry_run and queue_is_full:
-                    # One or more of the queues is full
+                    # One or more of the queues are full
                     current_time = datetime.now()
                     elapsed_time = current_time - iteration_start_time
                     elapsed_total_seconds = elapsed_time.total_seconds()
@@ -165,7 +165,7 @@ def process_user(user, cameras, time_ranges, token, wait_seconds, max_wait_time,
 
                     # Sleep to give queues time to drain
                     else:
-                        sys.stderr.write(f"Queue is full, sleeping for {wait_seconds}s. Queue lengths: {queue_lengths}\n")
+                        sys.stderr.write(f"One or more queues are full, sleeping for {wait_seconds}s. Queue lengths: {queue_lengths}\n")
                         time.sleep(wait_seconds)
 
                 else:

--- a/utils/upload_everything/upload_everything.py
+++ b/utils/upload_everything/upload_everything.py
@@ -15,7 +15,7 @@ limitations under the License.
 
 
 Execute with:
-python upload_everything.py --cameras_filename your_cameras_filename.csv --time_range_filename your_time_range_filename.csv --token your_access_token --device_ids camio_box_device_id_1 camio_box_device_id_1 --max_wait_time 600
+python upload_everything.py --cameras_filename your_cameras_filename.csv --time_range_filename your_time_range_filename.csv --token your_access_token --device_ids "camio_box_device_id_1" "camio_box_device_id_2" --max_wait_time 600
 
 See help with:
 python upload_everything.py --help
@@ -42,7 +42,7 @@ https://camio.com/settings/integrations/#api
 The stdout is a CSV with five columns like this example, where the search_url can be used to view the results the requested
 uploads are completed:
 
-python upload_everything.py --cameras_filename cameras.csv --time_range_filename time-ranges.csv --token YOURTOKEN --device_ids camio_box_device_id_1 camio_box_device_id_1 --max_wait_time 600 | tee output.csv
+python upload_everything.py --cameras_filename cameras.csv --time_range_filename time-ranges.csv --token YOURTOKEN --device_ids "camio_box_device_id_1" "camio_box_device_id_2" --max_wait_time 600 | tee output.csv
 
 timestamp,api_request_url,status,upload_commands_count,uploading_devices,search_url
 2024-02-05T14:56:39.197221,https://camio.com/api/search?text=sanmateo%40camiolog.com+Front+East+7pm+PT+January+31st+to+8pm+PT+January+31st+all+tag%3Abox,200,2,0,gd:00vx12273wf6fvd:000C29EF1F22 gd:00vx12273wf6fvd:B0416F040AF6,https://camio.com/app/#search;q=sanmateo%40camiolog.com+Front+East+7pm+PT+January+31st+to+8pm+PT+January+31st+all
@@ -217,19 +217,19 @@ if __name__ == "__main__":
                         help='Path to the time range filename with CSV start_time,end_time.')
     parser.add_argument('--token', required=True,
                         help='Access token for API (obtain from https://camio.com/settings/integrations/#api).')
-    parser.add_argument('--wait_seconds', required=False, default=500,
+    parser.add_argument('--wait_seconds', required=False, default=500, type=int,
                         help='Wait time between each request in seconds (default 500 for 1 hour of 89-stream 1775R).')
     parser.add_argument('--hostname', required=False, default='camio.com',
                         help='The hostname of the API endpoint (default is camio.com).')
     parser.add_argument('--device_ids', nargs='+', required=False, default=[],
                         help='List of device IDs to check the upload queue length of.')
-    parser.add_argument('--upload_queue_threshold', required=False, default=500,
+    parser.add_argument('--upload_queue_threshold', required=False, default=500, type=int,
                         help='Only perform the upload requests when the upload queue is below this threshold of pending tasks.')
-    parser.add_argument('--max_wait_time', required=False, default=3600,
+    parser.add_argument('--max_wait_time', required=False, default=3600, type=int,
                         help='How long to continue waiting if the upload queue is full, before breaking iteration, in seconds.')  # Default of 1 hour
     parser.add_argument('--dry_run', action='store_true', help='Perform a dry run (skip actual API requests).')
 
     args = parser.parse_args()
 
-    process_files(args.cameras_filename, args.time_range_filename, args.token, int(args.wait_seconds),
-                  int(args.max_wait_time), args.hostname, args.device_ids, int(args.upload_queue_threshold), args.dry_run)
+    process_files(args.cameras_filename, args.time_range_filename, args.token, args.wait_seconds,
+                  args.max_wait_time, args.hostname, args.device_ids, args.upload_queue_threshold, args.dry_run)

--- a/utils/upload_everything/upload_everything.py
+++ b/utils/upload_everything/upload_everything.py
@@ -42,7 +42,7 @@ https://camio.com/settings/integrations/#api
 The stdout is a CSV with five columns like this example, where the search_url can be used to view the results the requested
 uploads are completed:
 
-python upload_everything.py --cameras_filename cameras.csv --time_range_filename time-ranges.csv --token YOURTOKEN --device_ids camio_box_device_id_1 camio_box_device_id_1 | tee output.csv
+python upload_everything.py --cameras_filename cameras.csv --time_range_filename time-ranges.csv --token YOURTOKEN --device_ids camio_box_device_id_1 camio_box_device_id_1 --max_wait_time 600 | tee output.csv
 
 timestamp,api_request_url,status,upload_commands_count,uploading_devices,search_url
 2024-02-05T14:56:39.197221,https://camio.com/api/search?text=sanmateo%40camiolog.com+Front+East+7pm+PT+January+31st+to+8pm+PT+January+31st+all+tag%3Abox,200,2,0,gd:00vx12273wf6fvd:000C29EF1F22 gd:00vx12273wf6fvd:B0416F040AF6,https://camio.com/app/#search;q=sanmateo%40camiolog.com+Front+East+7pm+PT+January+31st+to+8pm+PT+January+31st+all
@@ -105,58 +105,76 @@ def get_upload_queue_lengths(user, token, hostname, device_ids_to_check, dry_run
     return queue_lengths
 
 
-def process_user(user, cameras, time_ranges, token, wait_seconds, hostname, device_ids_to_check,
+def process_user(user, cameras, time_ranges, token, wait_seconds, max_wait_time, hostname, device_ids_to_check,
                  upload_queue_threshold, dry_run=False):
     # Proceeding with the search API request
     for camera_name in cameras:
         for time_range in time_ranges:
-            start_time, end_time = time_range
-            concatenated_string = f"{user} {camera_name} {start_time} to {end_time} all tag:box"
-            call_time = datetime.now()
+            iteration_start_time = datetime.now()
 
-            # Get the queue lengths for the specified boxes, will be [] if none specified
-            queue_lengths = get_upload_queue_lengths(user=user, token=token, hostname=hostname,
-                                                     device_ids_to_check=device_ids_to_check, dry_run=dry_run)
-            queue_lengths_string = ' '.join(str(length) for length in queue_lengths)
-            queue_is_full = not all(value < upload_queue_threshold for value in queue_lengths)
+            while True:
+                start_time, end_time = time_range
+                concatenated_string = f"{user} {camera_name} {start_time} to {end_time} all tag:box"
+                call_time = datetime.now()
 
-            # Don't request tag:box upload for dry runs or if the queue is filling up
-            if not dry_run and not queue_is_full:
-                response = make_api_request(concatenated_string, token, hostname)
-                search_url = response.url.replace("/api/search?text=", "/app/#search;q=").replace("+tag%3Abox", "")
-                upload_commands_count = 0
-                uploading_devices = ''
-                is_working = False
-                if response.status_code // 100 == 2:  # in the 2xx range
-                    response_data = response.json()
-                    if 'operations' in response_data and 'upload_commands' in response_data[
-                        'operations'] and isinstance(response_data['operations']['upload_commands'], list):
-                        upload_commands = response_data['operations']['upload_commands']
-                        upload_commands_count = len(upload_commands)
-                        uploading_devices = ' '.join(
-                            upload_command["device_id_internal"] for upload_command in upload_commands)
-                        is_working = True
+                # Get the queue lengths for the specified boxes, will be [] if none specified
+                queue_lengths = get_upload_queue_lengths(user=user, token=token, hostname=hostname,
+                                                         device_ids_to_check=device_ids_to_check, dry_run=dry_run)
+                queue_lengths_string = ' '.join(str(length) for length in queue_lengths)
+                queue_is_full = not all(value < upload_queue_threshold for value in queue_lengths)
+
+                # Don't request tag:box upload for dry runs or if the queue is filling up
+                if not dry_run and not queue_is_full:
+                    response = make_api_request(concatenated_string, token, hostname)
+                    search_url = response.url.replace("/api/search?text=", "/app/#search;q=").replace("+tag%3Abox", "")
+                    upload_commands_count = 0
+                    uploading_devices = ''
+                    is_working = False
+                    if response.status_code // 100 == 2:  # in the 2xx range
+                        response_data = response.json()
+                        if 'operations' in response_data and 'upload_commands' in response_data[
+                            'operations'] and isinstance(response_data['operations']['upload_commands'], list):
+                            upload_commands = response_data['operations']['upload_commands']
+                            upload_commands_count = len(upload_commands)
+                            uploading_devices = ' '.join(
+                                upload_command["device_id_internal"] for upload_command in upload_commands)
+                            is_working = True
+                    else:
+                        sys.stderr.write(f"Error making upload request: {response.status_code} ({response.reason})\n")
+
+                    print(
+                        f"{call_time.isoformat()},{response.url},{response.status_code},{upload_commands_count},{queue_lengths_string},{uploading_devices},{search_url}")
+                    sys.stdout.flush()
+                    if is_working:
+                        time.sleep(wait_seconds)
+                    break
+
+                elif not dry_run and queue_is_full:
+                    # One or more of the queues is full
+                    current_time = datetime.now()
+                    elapsed_time = current_time - iteration_start_time
+                    elapsed_total_seconds = elapsed_time.total_seconds()
+
+                    # Break iteration if reached max wait time
+                    if elapsed_total_seconds > max_wait_time:
+                        sys.stderr.write(f"Waited for max {max_wait_time}s for user {user}, camera {camera_name}\n")
+                        print(
+                            f"{call_time.isoformat()},{concatenated_string},N/A,N/A,{queue_lengths_string},N/A,N/A")
+                        break
+
+                    # Sleep to give queues time to drain
+                    else:
+                        sys.stderr.write(f"Queue is full, sleeping for {wait_seconds}s. Queue lengths: {queue_lengths}\n")
+                        time.sleep(wait_seconds)
+
                 else:
-                    sys.stderr.write(f"Error making upload request: {response.status_code} ({response.reason})\n")
-
-                print(
-                    f"{call_time.isoformat()},{response.url},{response.status_code},{upload_commands_count},{queue_lengths_string},{uploading_devices},{search_url}")
-                sys.stdout.flush()
-                if is_working:
-                    time.sleep(wait_seconds)
-
-            elif not dry_run and queue_is_full:
-                # If the queue is full, wait for it to drain
-                sys.stderr.write(f"Queue is full, sleeping for {wait_seconds}s. Queue lengths: {queue_lengths}\n")
-                time.sleep(wait_seconds)
-
-            else:
-                print(f"{call_time.isoformat()},{concatenated_string},N/A,{queue_lengths_string},0,N/A")
-                sys.stdout.flush()
+                    print(f"{call_time.isoformat()},{concatenated_string},N/A,0,{queue_lengths_string},N/A")
+                    sys.stdout.flush()
+                    break
 
 
-def process_files(cameras_filename, time_range_filename, token, wait_seconds, hostname, device_ids_to_check,
-                  upload_queue_threshold, dry_run=False):
+def process_files(cameras_filename, time_range_filename, token, wait_seconds, max_wait_time, hostname,
+                  device_ids_to_check, upload_queue_threshold, dry_run=False):
     time_ranges = []
     with open(time_range_filename, 'r') as file:
         reader = csv.DictReader(file)
@@ -185,7 +203,7 @@ def process_files(cameras_filename, time_range_filename, token, wait_seconds, ho
     with ThreadPoolExecutor() as executor:  # Python version 3.8: Default value of max_workers is changed to min(32, os.cpu_count() + 4)
         for user, cameras in users_cameras.items():
             row_count += len(cameras)
-            executor.submit(process_user, user, cameras, time_ranges, token, wait_seconds, hostname,
+            executor.submit(process_user, user, cameras, time_ranges, token, wait_seconds, max_wait_time, hostname,
                             device_ids_to_check, upload_queue_threshold, dry_run)
 
 
@@ -206,9 +224,11 @@ if __name__ == "__main__":
                         help='List of device IDs to check the upload queue length of.')
     parser.add_argument('--upload_queue_threshold', required=False, default=500,
                         help='Only perform the upload requests when the upload queue is below this threshold of pending tasks.')
+    parser.add_argument('--max_wait_time', required=False, default=3600,
+                        help='How long to continue waiting if the upload queue is full, before breaking iteration, in seconds.')  # Default of 1 hour
     parser.add_argument('--dry_run', action='store_true', help='Perform a dry run (skip actual API requests).')
 
     args = parser.parse_args()
 
-    process_files(args.cameras_filename, args.time_range_filename, args.token, int(args.wait_seconds), args.hostname,
-                  args.device_ids, int(args.upload_queue_threshold), args.dry_run)
+    process_files(args.cameras_filename, args.time_range_filename, args.token, int(args.wait_seconds),
+                  int(args.max_wait_time), args.hostname, args.device_ids, int(args.upload_queue_threshold), args.dry_run)

--- a/utils/upload_everything/upload_everything.py
+++ b/utils/upload_everything/upload_everything.py
@@ -160,6 +160,7 @@ def process_user(user, cameras, time_ranges, token, wait_seconds, max_wait_time,
                         sys.stderr.write(f"Waited for max {max_wait_time}s for user {user}, camera {camera_name}\n")
                         print(
                             f"{call_time.isoformat()},{concatenated_string},N/A,N/A,{queue_lengths_string},N/A,N/A")
+                        sys.stdout.flush()
                         break
 
                     # Sleep to give queues time to drain

--- a/utils/upload_everything/upload_everything.py
+++ b/utils/upload_everything/upload_everything.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-Excecute with:
-python upload_everything.py --cameras_filename your_cameras_filename.csv --time_range_filename your_time_range_filename.csv --token your_access_token
+Execute with:
+python upload_everything.py --cameras_filename your_cameras_filename.csv --time_range_filename your_time_range_filename.csv --token your_access_token --device_ids camio_box_device_id_1 camio_box_device_id_1
 
 See help with:
 python upload_everything.py --help
@@ -39,16 +39,16 @@ start_time,end_time
 You can obtain your_access_token from:
 https://camio.com/settings/integrations/#api
 
-The stdout is a CSV with four columns like this example, where the search_url can be used to view the results the requested
+The stdout is a CSV with five columns like this example, where the search_url can be used to view the results the requested
 uploads are completed:
 
-python upload_everything.py --cameras_filename cameras.csv --time_range_filename time-ranges.csv --token YOURTOKEN | tee output.csv
+python upload_everything.py --cameras_filename cameras.csv --time_range_filename time-ranges.csv --token YOURTOKEN --device_ids camio_box_device_id_1 camio_box_device_id_1 | tee output.csv
 
 timestamp,api_request_url,status,upload_commands_count,uploading_devices,search_url
-2024-02-05T14:56:39.197221,https://camio.com/api/search?text=sanmateo%40camiolog.com+Front+East+7pm+PT+January+31st+to+8pm+PT+January+31st+all+tag%3Abox,200,2,gd:00vx12273wf6fvd:000C29EF1F22 gd:00vx12273wf6fvd:B0416F040AF6,https://camio.com/app/#search;q=sanmateo%40camiolog.com+Front+East+7pm+PT+January+31st+to+8pm+PT+January+31st+all
-2024-02-05T14:56:40.197221,https://camio.com/api/search?text=sanmateo%40camiolog.com+Front+East+8pm+PT+January+31st+to+9pm+PT+January+31st+all+tag%3Abox,200,2,gd:00vx12273wf6fvd:000C29EF1F22 gd:00vx12273wf6fvd:B0416F040AF6,https://camio.com/app/#search;q=sanmateo%40camiolog.com+Front+East+8pm+PT+January+31st+to+9pm+PT+January+31st+all
-2024-02-05T14:56:41.197221,https://camio.com/api/search?text=sanmateo%40camiolog.com+Front+West+7pm+PT+January+31st+to+8pm+PT+January+31st+all+tag%3Abox,200,2,gd:00vx12273wf6fvd:000C29EF1F22 gd:00vx12273wf6fvd:B0416F040AF6,https://camio.com/app/#search;q=sanmateo%40camiolog.com+Front+West+7pm+PT+January+31st+to+8pm+PT+January+31st+all
-2024-02-05T14:56:42.197221,https://camio.com/api/search?text=sanmateo%40camiolog.com+Front+West+8pm+PT+January+31st+to+9pm+PT+January+31st+all+tag%3Abox,200,2,gd:00vx12273wf6fvd:000C29EF1F22 gd:00vx12273wf6fvd:B0416F040AF6,https://camio.com/app/#search;q=sanmateo%40camiolog.com+Front+West+8pm+PT+January+31st+to+9pm+PT+January+31st+all
+2024-02-05T14:56:39.197221,https://camio.com/api/search?text=sanmateo%40camiolog.com+Front+East+7pm+PT+January+31st+to+8pm+PT+January+31st+all+tag%3Abox,200,2,0,gd:00vx12273wf6fvd:000C29EF1F22 gd:00vx12273wf6fvd:B0416F040AF6,https://camio.com/app/#search;q=sanmateo%40camiolog.com+Front+East+7pm+PT+January+31st+to+8pm+PT+January+31st+all
+2024-02-05T14:56:40.197221,https://camio.com/api/search?text=sanmateo%40camiolog.com+Front+East+8pm+PT+January+31st+to+9pm+PT+January+31st+all+tag%3Abox,200,2,1,gd:00vx12273wf6fvd:000C29EF1F22 gd:00vx12273wf6fvd:B0416F040AF6,https://camio.com/app/#search;q=sanmateo%40camiolog.com+Front+East+8pm+PT+January+31st+to+9pm+PT+January+31st+all
+2024-02-05T14:56:41.197221,https://camio.com/api/search?text=sanmateo%40camiolog.com+Front+West+7pm+PT+January+31st+to+8pm+PT+January+31st+all+tag%3Abox,200,2,2,gd:00vx12273wf6fvd:000C29EF1F22 gd:00vx12273wf6fvd:B0416F040AF6,https://camio.com/app/#search;q=sanmateo%40camiolog.com+Front+West+7pm+PT+January+31st+to+8pm+PT+January+31st+all
+2024-02-05T14:56:42.197221,https://camio.com/api/search?text=sanmateo%40camiolog.com+Front+West+8pm+PT+January+31st+to+9pm+PT+January+31st+all+tag%3Abox,200,2,3,gd:00vx12273wf6fvd:000C29EF1F22 gd:00vx12273wf6fvd:B0416F040AF6,https://camio.com/app/#search;q=sanmateo%40camiolog.com+Front+West+8pm+PT+January+31st+to+9pm+PT+January+31st+all
 
 Only the tag:box upload request query text is shown when using the --dry_run argument like this:
 
@@ -76,7 +76,14 @@ def make_api_request(concatenated_string, token, hostname):
     return response
 
 
-def get_upload_queue_lengths(user, token, hostname, device_ids_to_check, dry_run=False):
+def get_upload_queue_lengths(user, token, hostname, device_ids_to_check, dry_run=False) -> list:
+    """
+    Requests /api/devices and extracts the upload_queue_length for specified device_ids_to_check. If dry_run or no
+    device_ids_to_check, returns an empty list. If the specified device ids are not found in the devices payload, returns
+    an empty list.
+
+    Ex: [0, 100, 20]
+    """
     if dry_run or not device_ids_to_check:
         return []
 
@@ -98,17 +105,23 @@ def get_upload_queue_lengths(user, token, hostname, device_ids_to_check, dry_run
     return queue_lengths
 
 
-def process_user(user, cameras, time_ranges, token, wait_seconds, hostname, device_ids_to_check, dry_run=False):
+def process_user(user, cameras, time_ranges, token, wait_seconds, hostname, device_ids_to_check,
+                 upload_queue_threshold, dry_run=False):
     # Proceeding with the search API request
     for camera_name in cameras:
         for time_range in time_ranges:
             start_time, end_time = time_range
             concatenated_string = f"{user} {camera_name} {start_time} to {end_time} all tag:box"
             call_time = datetime.now()
+
+            # Get the queue lengths for the specified boxes, will be [] if none specified
             queue_lengths = get_upload_queue_lengths(user=user, token=token, hostname=hostname,
                                                      device_ids_to_check=device_ids_to_check, dry_run=dry_run)
             queue_lengths_string = ' '.join(str(length) for length in queue_lengths)
-            if not dry_run and all(value < 500 for value in queue_lengths):
+            queue_is_full = not all(value < upload_queue_threshold for value in queue_lengths)
+
+            # Don't request tag:box upload for dry runs or if the queue is filling up
+            if not dry_run and not queue_is_full:
                 response = make_api_request(concatenated_string, token, hostname)
                 search_url = response.url.replace("/api/search?text=", "/app/#search;q=").replace("+tag%3Abox", "")
                 upload_commands_count = 0
@@ -132,9 +145,9 @@ def process_user(user, cameras, time_ranges, token, wait_seconds, hostname, devi
                 if is_working:
                     time.sleep(wait_seconds)
 
-            elif not dry_run and not all(value < 500 for value in queue_lengths):
+            elif not dry_run and queue_is_full:
                 # If the queue is full, wait for it to drain
-                sys.stderr.write(f"Queue is full, sleeping. Queue lengths: {queue_lengths}")
+                sys.stderr.write(f"Queue is full, sleeping for {wait_seconds}s. Queue lengths: {queue_lengths}\n")
                 time.sleep(wait_seconds)
 
             else:
@@ -143,7 +156,7 @@ def process_user(user, cameras, time_ranges, token, wait_seconds, hostname, devi
 
 
 def process_files(cameras_filename, time_range_filename, token, wait_seconds, hostname, device_ids_to_check,
-                  dry_run=False):
+                  upload_queue_threshold, dry_run=False):
     time_ranges = []
     with open(time_range_filename, 'r') as file:
         reader = csv.DictReader(file)
@@ -167,13 +180,13 @@ def process_files(cameras_filename, time_range_filename, token, wait_seconds, ho
 
     row_count = 0
     print(
-        f"timestamp,api_request_url,status,upload_commands_count,upload_queue_lenths,uploading_devices,search_url")  # header row
+        f"timestamp,api_request_url,status,upload_commands_count,upload_queue_lengths,uploading_devices,search_url")  # header row
 
     with ThreadPoolExecutor() as executor:  # Python version 3.8: Default value of max_workers is changed to min(32, os.cpu_count() + 4)
         for user, cameras in users_cameras.items():
             row_count += len(cameras)
             executor.submit(process_user, user, cameras, time_ranges, token, wait_seconds, hostname,
-                            device_ids_to_check, dry_run)
+                            device_ids_to_check, upload_queue_threshold, dry_run)
 
 
 if __name__ == "__main__":
@@ -190,10 +203,12 @@ if __name__ == "__main__":
     parser.add_argument('--hostname', required=False, default='camio.com',
                         help='The hostname of the API endpoint (default is camio.com).')
     parser.add_argument('--device_ids', nargs='+', required=False, default=[],
-                        help='List of device IDs to check the upload queue for.')
+                        help='List of device IDs to check the upload queue length of.')
+    parser.add_argument('--upload_queue_threshold', required=False, default=500,
+                        help='Only perform the upload requests when the upload queue is below this threshold of pending tasks.')
     parser.add_argument('--dry_run', action='store_true', help='Perform a dry run (skip actual API requests).')
 
     args = parser.parse_args()
 
     process_files(args.cameras_filename, args.time_range_filename, args.token, int(args.wait_seconds), args.hostname,
-                  args.device_ids, args.dry_run)
+                  args.device_ids, int(args.upload_queue_threshold), args.dry_run)


### PR DESCRIPTION
Modifies `upload_everything.py` to check the upload queue length for the specified Camio devices (`--device_ids`) before requesting more uploads via `tag:box` search request. Queue length is checked by calling `/api/devices` and parsing the response to extract the queue lengths. The goal of this change is to allow the script to continue running without having to manually halt it, while also preventing the script from adding additional upload requests if the upload queue is already full.

#### New script arguments:
- `--device_ids`: If passed, these device ids will have their upload queue length checked before the upload request is made
- `--max_wait_time`: The maximum number of seconds to wait for the upload queue to drain before giving up and continuing to the next camera/time range. Default is 1 hour.
   - For a script run that's restricted to one box, `max_wait_time` could be set very high since all of the cameras are for the same box (i.e. can move on to the next camera but already know that the queue is full so will just being waiting again)
   - For a script run across multiple accounts/boxes, I would recommend a lower `max_wait_time`
   - If a line is skipped due to reaching the `max_wait_time`, a line will be written to `stderr` and the `output.csv` will contain a line with `N/A` for the `status`
- `--upload_queue_threshold`: The threshold at which to not request uploads and wait instead. Default is `500`.

### Sample run commands:

Here are sample test runs that I performed (api token and device id omitted). @PaigeRiola I would appreciate it you could also test these yourself, and any other argument combinations you can think of. The repo already contains sample `time-ranges.csv` and `cameras.csv` files, which you can modify or leave as is.

#### Dry run
```
python upload_everything.py --hostname test.camio.com --cameras_filename cameras.csv --time_range_filename time-ranges.csv --token {{YOUR_CAMIO_API_TOKEN}} --dry_run | tee output.csv
```

#### Without checking upload queues
```
python upload_everything.py --hostname test.camio.com --cameras_filename cameras.csv --time_range_filename time-ranges.csv --token {{YOUR_CAMIO_API_TOKEN}} | tee output.csv
```

#### Checking upload queues
```
python upload_everything.py --hostname test.camio.com --cameras_filename cameras.csv --time_range_filename time-ranges.csv --token {{YOUR_CAMIO_API_TOKEN}} --device_ids {{YOUR_DEVICE_ID}} --wait_seconds 10 --max_wait_time 60 | tee output.csv
```

#### "Full" upload queues
```
python upload_everything.py --hostname test.camio.com --cameras_filename cameras.csv --time_range_filename time-ranges.csv --token {{YOUR_CAMIO_API_TOKEN}} --device_ids {{YOUR_DEVICE_ID}} --wait_seconds 10 --upload_queue_threshold 0 --max_wait_time 60 | tee output.csv
```
