### PR TITLE
ABC Fitness Integration Driver - Default Polling Interval

### DIFF
--- a/integrations/driver/README.md
+++ b/integrations/driver/README.md
@@ -1,6 +1,6 @@
 # Camio Integration Drivers
 
-Camio Integration drivers continuously poll an external integration's API for information to forward into the Camio 
+Camio Integration drivers periodically poll an external integration's API for information to forward into the Camio 
 system. 
 
 ## Repo Structure

--- a/integrations/driver/app/base.py
+++ b/integrations/driver/app/base.py
@@ -484,6 +484,7 @@ class BaseIntegrationDriver:
                     if self.is_time_to_reset_event_count():
                         self.reset_event_count()
 
+                self.logger.info(f"Sleeping for {self.events_polling_interval}s")
                 sleep(self.events_polling_interval)
 
             except Exception as e:  # Continue for best effort, if event streaming fails this also ensures a re-try
@@ -818,7 +819,7 @@ class TestBaseIntegrationDriver(unittest.IsolatedAsyncioTestCase):
 
     async def test_run(self):
         """
-        Tests the continuous event and devices fetching that occurs in run(). If event streaming is enabled this test
+        Tests the periodic event and devices fetching that occurs in run(). If event streaming is enabled this test
         can take a while, since it will start event streaming, send events, and wait for the events to come into the
         streaming response. Relies on the yields in the BaseIntegrationDriver to function properly.
 

--- a/integrations/driver/configs/production/abc_fitness_config.yaml
+++ b/integrations/driver/configs/production/abc_fitness_config.yaml
@@ -15,7 +15,7 @@ urls:
 
 requests:
   devices:
-    polling_interval: 7200  # every 2 hours
+    polling_interval: 43200  # in seconds, how frequently to request station information via the ABC Fitness API. Defaults to every 12 hours
 
   pacs:
     backoff_multiplier: 2.0  # multiplier for increasing sleep between retries
@@ -25,7 +25,7 @@ requests:
   events:
     streaming: false  # ABC Fitness API does not support streaming
     count_reset_interval: 86400  # reset the events count every 24 hours
-    polling_interval: 900  # in seconds, how frequently to request checkin information via the ABC Fitness API. Defaults to every 15 minutes
+    polling_interval: 43200  # in seconds, how frequently to request checkin information via the ABC Fitness API. Defaults to every 12 hours
     timezone_offset:  # Timezone offset for the timestamps of the events. Format is +/-HHMM. Examples: -0700, +0100. Does not account for daylight savings time, since the number is always added/subtracted from the UTC time. Default is None.
     timezone_name: "UTC"  # Name of the timezone that the event timestamps are in. Uses pytz timezones. If timezone_offset is also passed, will use the offset over the timezone name. Should account for daylight savings. Examples: US/Central, US/Eastern, US/Pacific, Europe/Paris. Default is UTC.
     get_member_info: true

--- a/integrations/driver/configs/test/abc_fitness_config.yaml
+++ b/integrations/driver/configs/test/abc_fitness_config.yaml
@@ -15,7 +15,7 @@ urls:
 
 requests:
   devices:
-    polling_interval: 7200  # every 2 hours
+    polling_interval: 43200  # in seconds, how frequently to request station information via the ABC Fitness API. Defaults to every 12 hours
 
   pacs:
     backoff_multiplier: 2.0  # multiplier for increasing sleep between retries
@@ -25,7 +25,7 @@ requests:
   events:
     streaming: false  # ABC Fitness API does not support streaming
     count_reset_interval: 86400  # reset the events count every 24 hours
-    polling_interval: 900  # in seconds, how frequently to request checkin information via the ABC Fitness API. Defaults to every 15 minutes
+    polling_interval: 900  # in seconds, how frequently to request checkin information via the ABC Fitness API. Defaults to every 12 hours but for testing is set here to 15 minutes
     timezone_offset:  # Timezone offset for the timestamps of the events. Format is +/-HHMM. Examples: -0700, +0100. Does not account for daylight savings time, since the number is always added/subtracted from the UTC time. Default is None.
     timezone_name: "UTC"  # Name of the timezone that the event timestamps are in. Uses pytz timezones. If timezone_offset is also passed, will use the offset over the timezone name. Should account for daylight savings. Examples: US/Central, US/Eastern, US/Pacific, Europe/Paris. Default is UTC.
     get_member_info: true

--- a/integrations/driver/helm/abc_fitness_values.yaml
+++ b/integrations/driver/helm/abc_fitness_values.yaml
@@ -12,7 +12,7 @@ urls:
 
 requests:
   devices:
-    polling_interval: 7200  # every 2 hours
+    polling_interval: 43200  # in seconds, how frequently to request station information via the ABC Fitness API. Defaults to every 12 hours
 
   pacs:
     backoff_multiplier: 2.0  # multiplier for increasing sleep between retries
@@ -21,6 +21,7 @@ requests:
 
   events:
     streaming: false  # ABC Fitness API does not support streaming
+    polling_interval: 43200  # in seconds, how frequently to request checkin information via the ABC Fitness API. Defaults to every 12 hours
     count_reset_interval: 86400  # reset the events count every 24 hours
     timezone_offset:  # Timezone offset for the timestamps of the events. Format is +/-HHMM. Examples: -0700, +0100. Does not account for daylight savings time, since the number is always added/subtracted from the UTC time. Default is None.
     timezone_name: "UTC"  # Name of the timezone that the event timestamps are in. Uses pytz timezones. If timezone_offset is also passed, will use the offset over the timezone name. Should account for daylight savings. Examples: US/Central, US/Eastern, US/Pacific, Europe/Paris. Default is UTC.

--- a/integrations/driver/helm/camio-abc-fitness/templates/driver-cm0-configmap.yaml
+++ b/integrations/driver/helm/camio-abc-fitness/templates/driver-cm0-configmap.yaml
@@ -19,14 +19,14 @@ data:
 
     requests:
       devices:
-        polling_interval: {{ .Values.requests.devices.polling_interval }}
+        polling_interval: {{ .Values.requests.devices.polling_interval | default 43200 }}
       pacs:
         backoff_multiplier:  {{ .Values.requests.pacs.backoff_multiplier }}
         backoff_start: {{ .Values.requests.pacs.backoff_start }}
         backoff_limit: {{ .Values.requests.pacs.backoff_limit }}
       events:
         streaming: false  # MUST be false
-        polling_interval: {{ .Values.requests.events.polling_interval | default 900 }}
+        polling_interval: {{ .Values.requests.events.polling_interval | default 43200 }}
         count_reset_interval: {{ .Values.requests.events.count_reset_interval }}
         timezone_offset: {{ .Values.requests.events.timezone_offset }}
         timezone_name: {{ .Values.requests.events.timezone_name }}

--- a/integrations/driver/helm/camio-abc-fitness/values.yaml
+++ b/integrations/driver/helm/camio-abc-fitness/values.yaml
@@ -12,7 +12,7 @@ urls:
 
 requests:
   devices:
-    polling_interval: 7200  # every 2 hours
+    polling_interval: 43200  # in seconds, how frequently to request station information via the ABC Fitness API. Defaults to every 12 hours
 
   pacs:
     backoff_multiplier: 2.0  # multiplier for increasing sleep between retries
@@ -21,6 +21,7 @@ requests:
 
   events:
     streaming: false  # ABC Fitness API does not support streaming
+    polling_interval: 43200  # in seconds, how frequently to request checkin information via the ABC Fitness API. Defaults to every 12 hours
     count_reset_interval: 86400  # reset the events count every 24 hours
     timezone_offset:  # Timezone offset for the timestamps of the events. Format is +/-HHMM. Examples: -0700, +0100. Does not account for daylight savings time, since the number is always added/subtracted from the UTC time. Default is None.
     timezone_name: "UTC"  # Name of the timezone that the event timestamps are in. Uses pytz timezones. If timezone_offset is also passed, will use the offset over the timezone name. Should account for daylight savings. Examples: US/Central, US/Eastern, US/Pacific, Europe/Paris. Default is UTC.


### PR DESCRIPTION
Updates the default polling interval to be 12 hours for both event and device polling. Previously was 15 minutes for events and 2 hours for devices. Also adds a log before sleeping with the duration of the sleep.