### PR TITLE
Camio ABC Fitness Driver Updates

### DIFF
--- a/integrations/driver/ABCFitnessREADME.md
+++ b/integrations/driver/ABCFitnessREADME.md
@@ -32,7 +32,7 @@ There are 3 options for running the ABC Fitness driver:
 ## Quick Install with Docker
 
 If docker is already installed, and you have cloned this repository, then you can use the provided quick install script, 
-`abc_fitness_quick_install.sh`, to run the Camio ABC Fitness driver. The quick install script:
+`abc_fitness_quick_install_docker.sh`, to run the Camio ABC Fitness driver. The quick install script:
 
 1. Populates the config file with your credentials
 2. Builds the docker image
@@ -46,7 +46,7 @@ need to contact ABC.
 Then, run from within this directory (`camio-integrations/driver`).
 
 ```
-bash abc_fitness_quick_install.sh [APP_KEY] [APP_ID] [CLUB_ID] [CAMIO_API_TOKEN]
+bash abc_fitness_quick_install_docker.sh [APP_KEY] [APP_ID] [CLUB_ID] [CAMIO_API_TOKEN]
 ```
 
 **NOTE**: The quick install uses the `linux-amd64` driver image by default. If you would like to run the `linux-arm64` 

--- a/integrations/driver/ABCFitnessREADME.md
+++ b/integrations/driver/ABCFitnessREADME.md
@@ -1,9 +1,5 @@
 ## Initial Setup 
 
-### Clone this Repositroy
-
-Refer to the GitHub documentation on [how to clone a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
-
 ### How to Run the ABC Fitness Driver
 
 There are 3 options for running the ABC Fitness driver:
@@ -24,20 +20,19 @@ There are 3 options for running the ABC Fitness driver:
 - If you are running the driver using Docker or Helm, you will need to install Docker
    - [Docker Engine](https://docs.docker.com/engine/install/ubuntu/) - for command line use only
    - Or [Docker Desktop](https://docs.docker.com/get-docker/) - for an interactive desktop app as well as command line
-   - Alternatively, you can install Docker using the provided [bash installation script](./install_docker.sh) 
+   - Alternatively, you can install Docker using the provided [bash installation script](./install_docker.sh). **Note 
+   that this script runs apt-get update and apt-get install**.
 - If you are going to run the driver using the provided Helm chart, you will also need:
    - A running [Kubernetes](https://kubernetes.io/docs/setup/) cluster such as [MicroK8s](https://microk8s.io/docs/getting-started)
    - [Helm](https://helm.sh/docs/intro/install/)
-   - A docker image [registry/repository](https://docs.docker.com/guides/docker-concepts/the-basics/what-is-a-registry/)
-   that your cluster can pull from
 - Alternatively, you can run the driver directly as Python code. To do so you will need to:
    - Install the [apt requirements](./apt_requirements.txt)
    - Install the Python [requirements](./requirements.txt) using [pip](https://packaging.python.org/en/latest/tutorials/installing-packages/#ensure-you-can-run-pip-from-the-command-line)
 
 ## Quick Install with Docker
 
-If docker is already installed, you can use the provided quick install script, `abc_fitness_quick_install.sh`, to run
-the Camio ABC Fitness driver. The quick install script:
+If docker is already installed, and you have cloned this repository, then you can use the provided quick install script, 
+`abc_fitness_quick_install.sh`, to run the Camio ABC Fitness driver. The quick install script:
 
 1. Populates the config file with your credentials
 2. Builds the docker image
@@ -48,11 +43,15 @@ First retrieve your credentials. You can generate a Camio API token on [this pag
 You can retrieve your ABC Fitness API key and ID by signing in [here](https://abcfinancial.3scale.net/docs). You may
 need to contact ABC.
 
-Then, run from within this directory (`examples/integrations/driver`).
+Then, run from within this directory (`camio-integrations/driver`).
 
 ```
 bash abc_fitness_quick_install.sh [APP_KEY] [APP_ID] [CLUB_ID] [CAMIO_API_TOKEN]
 ```
+
+**NOTE**: The quick install uses the `linux-amd64` driver image by default. If you would like to run the `linux-arm64` 
+driver image instead, change the image in the [docker compose file](./abc-fitness-docker-compose.yaml) to 
+`us-central1-docker.pkg.dev/camiologger/public-containers/camio-integration-driver-abc-fitness:latest-linux-arm64`.
 
 ### Re-Run the Quick Install
 
@@ -64,11 +63,142 @@ docker compose -f abc-fitness-docker-compose.yaml down
 
 Then run the quick install script again. Note that only one backup config file will be kept.
 
-## Create the Driver Image [Helm/Docker Setup]
+## Run the Driver using Docker (Non-Quick Install)
+
+### Create a Config File
+
+If you have not cloned this repository, copy or download the file [production config file](./configs/production/abc_fitness_config.yaml). 
+Enter your values into the config file. The `credentials` values are all required in order for the driver to 
+contact the ABC Fitness and Camio API.
+
+You can retrieve your ABC Fitness credentials [here](https://abcfinancial.3scale.net/docs). You may
+need to contact ABC.
+
+#### Required config values:
+
+| Field | Description | Default |
+| --- | --- | --- |
+| credentials.app_key | Your app key provided by ABC Fitness for calling the ABC Fitness API | None |
+| credentials.app_id | Your app id provided by ABC Fitness for calling the ABC Fitness API | None | 
+| credentials.club_id | The club id (number) provided by ABC Fitness for calling the ABC Fitness API | None |
+| credentials.camio_api_token | A token for calling the Camio API, generated on [this page](https://camio.com/settings/integrations) | None |
+
+#### Optional config values of note:
+
+| Field | Description | Default |
+| --- | --- | --- |
+| log_level | The base level of logs that will be printed in the driver container. 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERR0R), 50 (CRITICAL) | 10 (INFO logs and up) |
+| requests.events.polling_interval | How frequently to request the check in information from the ABC Fitness API. Defaults to every 12 hours. | 43200 (seconds) |
+| requests.events.get_member_info | If true, makes a request to the ABC Fitness API to fetch the member information for each checkin event. Enables Camio to send tailgating notifications to members by retrieving the member email. | true |
+| requests.devices.polling_interval | How frequently to request the station information from the ABC Fitness API. Defaults to every 12 hours. | 43200 (seconds) |
+
+### Start the Docker Container
+
+Run the driver container using the [docker compose file](./abc-fitness-docker-compose.yaml). Documentation on 
+[docker compose up](https://docs.docker.com/reference/cli/docker/compose/up/).
+
+If you have not cloned this repository, copy or download the docker compose file. Make sure to change 
+`./configs/production` in the docker compose file to the path of your config file from the previous step.
+
+Run this command from the directory containing the docker compose.
+
+```
+docker compose -f abc-fitness-docker-compose.yaml up -d
+```
+
+**NOTE**: The docker compose uses the `linux-amd64` driver image by default. If you would like to run the `linux-arm64` 
+driver image instead, change the image in the [docker compose](./abc-fitness-docker-compose.yaml) to 
+`us-central1-docker.pkg.dev/camiologger/public-containers/camio-integration-driver-abc-fitness:latest-linux-arm64`.
+
+## Run the Driver Using Helm
+
+### Create a Values File
+
+If you have not cloned this repository, copy or download the [values file](./helm/camio-abc-fitness/values.yaml). 
+Enter your credentials into the values file.
+
+The `credentials` values
+are all required in order for the driver to contact the ABC Fitness and Camio APIs. You can generate a Camio API token on 
+[this page](https://camio.com/settings/integrations). 
+
+#### Required values:
+
+| Field | Description | Default |
+| --- | --- | --- |
+| credentials.app_key | Your app key provided by ABC Fitness for calling the ABC Fitness API | None |
+| credentials.app_id | Your app id provided by ABC Fitness for calling the ABC Fitness API | None | 
+| credentials.club_id | The club id (number) provided by ABC Fitness for calling the ABC Fitness API | None |
+| credentials.camio_api_token | A token for calling the Camio API, generated on [this page](https://camio.com/settings/integrations) | None |
+
+#### Optional values of note:
+
+| Field | Description | Default |
+| --- | --- | --- |
+| log_level | The base level of logs that will be printed in the driver container. 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERR0R), 50 (CRITICAL) | 10 (INFO logs and up) |
+| requests.events.polling_interval | How frequently to request the check in information from the ABC Fitness API. Defaults to every 12 hours. | 43200 (seconds) |
+| requests.events.get_member_info | If true, makes a request to the ABC Fitness API to fetch the member information for each checkin event. Enables Camio to send tailgating notifications to members by retrieving the member email. | true |
+| requests.devices.polling_interval | How frequently to request the station information from the ABC Fitness API. Defaults to every 12 hours. | 43200 (seconds) |
+| container.image | The Camio ABC Fitness driver container image. Default to the amd-64 image. Can be changed to the arm64 image or to a custom image. | us-central1-docker.pkg.dev/camiologger/public-containers/camio-integration-driver-abc-fitness:latest-linux-amd64 |
+
+### Install the Helm Chart
+
+Run this command from the directory with your values.yaml file.
+
+```
+helm install camio-abc-fitness oci://us-central1-docker.pkg.dev/camiologger/helm/camio-abc-fitness --version 1.0.0 -f values.yaml -n camio --create-namespace
+```
+
+## Run the Driver Using Python [Not Recommended]
+
+Running the driver using python is a good method for testing your credentials but is not recommended for long term
+deployment.
+
+### Fill out the Config File
+
+Fill out the config file the same way as for the [docker deployment](#create-a-config-file).
+
+### Run the Driver
+
+```
+python3 app/abc_fitness.py --config configs/production/abc_fitness_config.yaml
+```
+
+# Uninstall
+
+### Docker
+
+```
+docker compose -f abc-fitness-docker-compose.yaml down
+```
+
+### Helm 
+
+```
+helm uninstall camio-abc-fitness-driver helm/camio-abc-fitness-1.0.0.tgz -f helm/camio-abc-fitness/values.yaml -n camio
+```
+
+### Python
+
+Control-C (Ctrl+C) to cancel the execution of the python file.
+
+# Custom Image Instructions
+
+The following is instructions for building your own Camio ABC Fitness driver image. You may want to create a custom image 
+if:
+- You want to modify the driver code
+- You want to changes to the driver dockerfile such as the base image etc.
+- You need an image for a platform that is not provided
+- You want the driver image uploaded to your own image registry
+
+## Clone this Repository
+
+Refer to the GitHub documentation on [how to clone a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
+
+## Create the Docker Driver Image
 
 ### Build the Docker Image
 
-Run from within this directory (`examples/integrations/driver`).
+Run from within this directory (`camio-integrations/driver`).
 
 ```
 docker build -t camio-integration-driver-abc-fitness:latest -f abc-fitnessDockerfile .
@@ -85,7 +215,7 @@ docker build -t camio-integration-driver-abc-fitness:latest --platform linux/amd
 
 ### [Optional] Push the Docker Image to a Registry
 
-You can upload the `camio-integration-driver-abc-fitness` to a Docker image registry if desired. Some options for image
+You can upload the `camio-integration-driver-abc-fitness` image to a Docker image registry if desired. Some options for image
 repositories are [Docker Hub](https://docs.docker.com/docker-hub/repos/create/) and cloud providers such as 
 [Google Cloud](https://cloud.google.com/artifact-registry) or [AWS](https://aws.amazon.com/ecr/). Once you have a 
 respository set up, you can push to that registry as follows:
@@ -97,107 +227,34 @@ docker push $REPOSITORY_IMAGE_NAME:latest
 
 **NOTE**: If using Helm, it is recommended to push the docker image to a registry.
 
-## Run the Driver Using Docker
+## Create a Helm Chart
 
-### Fill out the Config File
-
-Enter your values in the [production config file](./configs/production/abc_fitness_config.yaml). The `credentials` values
-are all required in order for the driver to contact the ABC Fitness and Camio API.
-
-You can generate a Camio API token on [this page](https://camio.com/settings/integrations).
-
-You can retrieve your ABC Fitness API key and ID by signing in [here](https://abcfinancial.3scale.net/docs). You may
-need to contact ABC.
-
-### Start the Docker Container
-
-Run the docker container using the [docker compose file](./abc-fitness-docker-compose.yaml). Make sure to change the 
-docker image if you've uploaded your docker image to a non-local registry. Documentation on [docker compose up](https://docs.docker.com/reference/cli/docker/compose/up/).
-
-Run this command from within this directory (`examples/integrations/driver`).
-
-```
-docker compose -f abc-fitness-docker-compose.yaml up -d
-```
-
-## Run the Driver Using Helm
+Below are the instructions for creating/pushing a custom Camio ABC Fitness driver Helm chart. First you will need to have
+either followed the custom docker image instructions above unless you want to use the provided docker images.
 
 ### Ensure that Your Cluster Has Access to the Driver Image
+
+If you are using the provided docker images, there is nothing to do for this step.
 
 If using a local docker image, you will need to make that docker image available to your kubernetes cluster. You may
 be able to push the local image directly to your clusters available images. For example, here is how you do so using 
 [MicroK8s](https://microk8s.io/docs/registry-images#working-with-locally-built-images-without-a-registry).
 
-If you uploaded your image to a non-local docker image registry you will need to ensure that your cluster can pull
+If you uploaded your docker image to a non-local docker image registry you will need to ensure that your cluster can pull
 from that registry. If the registry is publicly available, then most likely you can just use the image in the install 
-directions below with no problem. [MiroK8s documentation](https://microk8s.io/docs/registry-public) on using public 
+directions below with no problem. [MicroK8s documentation](https://microk8s.io/docs/registry-public) on using public 
 registries. Using a private registry will depend on the registry and the type of kubernetes cluster.
 
 
 ### Create the Helm Chart
 
-Create the Helm chart tgz file.
+Once you've made any desired changes to the Chart files, create the Helm chart tgz file by running:
 
 ```
 helm package helm/camio-abc-fitness
 ```
 
-### Fill out the Values File
+### [Optional] Upload the Helm Chart
 
-Enter your desired values in the [values file](./helm/abc_fitness_values.yaml). The `credentials` values
-are all required in order for the driver to contact the ABC Fitness and Camio API. You can generate a Camio API token on 
-[this page](https://camio.com/settings/integrations). You can retrieve your ABC Fitness API 
-key and ID by signing in [here](https://abcfinancial.3scale.net/docs). You may need to contact ABC.
-
-Make sure to change `container.image` to the image your cluster can access.
-
-### Install the Helm Chart
-
-Run this command from within this directory (`examples/integrations/driver`).
-
-```
-helm install camio-abc-fitness-driver helm/camio-abc-fitness-1.0.0.tgz -f helm/abc_fitness_values.yaml -n camio --create-namespace
-```
-
-## Run the Driver Using Python [Not Recommended]
-
-Running the driver using python is a good method for testing your credentials but is not recommended for long term
-deployment.
-
-### Fill out the Config File
-
-Enter your values in the [production config file](./configs/production/abc_fitness_config.yaml). The `credentials` values
-are all required in order for the driver to contact the ABC Fitness and Camio API.
-
-You can generate a Camio API token on [this page](https://camio.com/settings/integrations).
-
-You can retrieve your ABC Fitness `app_key`, `app_id` and `club_id` by signing in [here](https://abcfinancial.3scale.net/docs). You may
-need to contact ABC.
-
-### Run the Driver
-
-Run this command from within this directory (`examples/integrations/driver`).
-
-```
-python3 app/abc_fitness.py --config configs/production/abc_fitness_config.yaml
-```
-
-## Uninstall
-
-Run these commands from within this directory (`examples/integrations/driver`).
-
-### Docker
-
-```
-docker compose -f abc-fitness-docker-compose.yaml down
-```
-
-### Helm 
-
-```
-helm uninstall camio-abc-fitness-driver helm/camio-abc-fitness-1.0.0.tgz -f helm/abc_fitness_values.yaml -n camio
-```
-
-### Python
-
-Control-C (Ctrl+C) to cancel the execution of the python file.
+Upload the Helm chart to a [repository](https://helm.sh/docs/topics/chart_repository/) if desired. Cloud providers such 
+as GCP's [Artifact Registry](https://cloud.google.com/artifact-registry/docs/helm/manage-charts) can [host repositories](https://helm.sh/docs/topics/registries/#use-hosted-registries).

--- a/integrations/driver/abc-fitness-docker-compose.yaml
+++ b/integrations/driver/abc-fitness-docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   driver:
-    image: camio-integration-driver-abc-fitness:latest
+    image: us-central1-docker.pkg.dev/camiologger/public-containers/camio-integration-driver-abc-fitness:latest-linux-amd64
     restart: on-failure
     entrypoint: "python3 /app/abc_fitness.py --config /opt/configs/abc_fitness_config.yaml"
     volumes:

--- a/integrations/driver/abc_fitness_quick_install_docker.ps1
+++ b/integrations/driver/abc_fitness_quick_install_docker.ps1
@@ -1,0 +1,29 @@
+# Check if the correct number of arguments are provided
+if ($args.Length -ne 4) {
+    Write-Host "Usage: $0 app_key app_id club_id camio_api_token"
+    exit 1
+}
+
+# Assign command-line arguments to variables
+$app_key = $args[0]
+$app_id = $args[1]
+$club_id = $args[2]
+$camio_api_token = $args[3]
+
+# Define the config.yaml file path
+$config_file = "configs\production\abc_fitness_config.yaml"
+
+# Create a backup of the original config.yaml file
+Copy-Item -Path $config_file -Destination "$config_file.bak" -Force
+
+# Use -replace operator to update the values in the YAML file
+(Get-Content $config_file) -replace 'app_key:\s*".*"', "app_key: `"$app_key`"" `
+                          -replace 'app_id:\s*".*"', "app_id: `"$app_id`"" `
+                          -replace 'club_id:\s*".*"', "club_id: `"$club_id`"" `
+                          -replace 'camio_api_token:\s*".*"', "camio_api_token: `"$camio_api_token`"" |
+Out-File $config_file -Encoding utf8
+
+Write-Host "abc_fitness_config.yaml has been updated."
+
+# Run the docker compose
+docker-compose -f abc-fitness-docker-compose.yaml up -d

--- a/integrations/driver/abc_fitness_quick_install_docker.sh
+++ b/integrations/driver/abc_fitness_quick_install_docker.sh
@@ -26,8 +26,5 @@ sed -i '' -e "s/\(app_key:\s*\).*/\1 \"$app_key\"/" \
 
 echo "abc_fitness_config.yaml has been updated."
 
-# Build the image
-docker build -t camio-integration-driver-abc-fitness:latest --no-cache -f abc-fitnessDockerfile .
-
 # Run the docker compose
 docker compose -f abc-fitness-docker-compose.yaml up -d

--- a/integrations/driver/app/schemas.py
+++ b/integrations/driver/app/schemas.py
@@ -102,9 +102,9 @@ class BaseRequestConfigMap(BaseModel):
     """
     Configs specific to the URL being called.
     """
-    devices: BaseDevicesRequestConfig = Field(description="Config for requests to the integration's devices URL")
-    events: BaseEventsRequestConfig = Field(description="Config for requests to the integration's events URL")
-    pacs: BasePACSRequestConfig = Field(description="Config for requests to the Camio PACS server")
+    devices: BaseDevicesRequestConfig = Field(BaseDevicesRequestConfig(), description="Config for requests to the integration's devices URL")
+    events: BaseEventsRequestConfig = Field(BaseEventsRequestConfig(), description="Config for requests to the integration's events URL")
+    pacs: BasePACSRequestConfig = Field(BasePACSRequestConfig(), description="Config for requests to the Camio PACS server")
 
 
 class BaseIntegrationDriverConfig(BaseModel, extra=Extra.allow):
@@ -116,7 +116,8 @@ class BaseIntegrationDriverConfig(BaseModel, extra=Extra.allow):
     log_level: Literal[logging.DEBUG,
                        logging.INFO,
                        logging.WARNING,
-                       logging.ERROR] = Field(10, description="Python logging level. 10 is debug, 20 info, etc.")
+                       logging.ERROR,
+                       logging.CRITICAL] = Field(10, description="Python logging level. 10 is debug, 20 info, etc.")
     credentials: BaseCredentials = Field(None,
                                          description="Credentials used to authenticate with the integration's API")
     credentials_filepath: str = Field(None,

--- a/integrations/driver/configs/production/abc_fitness_config.yaml
+++ b/integrations/driver/configs/production/abc_fitness_config.yaml
@@ -5,31 +5,3 @@ credentials:
   app_id: "INSERT ABC FITNESS APP ID"
   club_id: "INSERT ABC FITNESS CLUB ID"
   camio_api_token: "INSERT CAMIO DEV TOKEN"
-
-urls:
-  devices: "https://api.abcfinancial.com/rest/{club_id}/clubs/stations"
-  events: "https://api.abcfinancial.com/rest/{club_id}/clubs/checkins/details"
-  members: "https://api.abcfinancial.com/rest/{club_id}/members"
-  pacs_server: "https://incoming.integrations.camio.com/pacs"
-  skip_ssl_verification: false
-
-requests:
-  devices:
-    polling_interval: 43200  # in seconds, how frequently to request station information via the ABC Fitness API. Defaults to every 12 hours
-
-  pacs:
-    backoff_multiplier: 2.0  # multiplier for increasing sleep between retries
-    backoff_start: 2.0  # initial seconds until retry, gets multiplied by backoff_multiplier after each attempt
-    backoff_limit: 3  # max number of retries
-
-  events:
-    streaming: false  # ABC Fitness API does not support streaming
-    count_reset_interval: 86400  # reset the events count every 24 hours
-    polling_interval: 43200  # in seconds, how frequently to request checkin information via the ABC Fitness API. Defaults to every 12 hours
-    timezone_offset:  # Timezone offset for the timestamps of the events. Format is +/-HHMM. Examples: -0700, +0100. Does not account for daylight savings time, since the number is always added/subtracted from the UTC time. Default is None.
-    timezone_name: "UTC"  # Name of the timezone that the event timestamps are in. Uses pytz timezones. If timezone_offset is also passed, will use the offset over the timezone name. Should account for daylight savings. Examples: US/Central, US/Eastern, US/Pacific, Europe/Paris. Default is UTC.
-    get_member_info: true
-    page_size: 100
-
-  members:
-    page_size: 100

--- a/integrations/driver/configs/test/abc_fitness_config.yaml
+++ b/integrations/driver/configs/test/abc_fitness_config.yaml
@@ -1,4 +1,4 @@
-log_level: 10  # DEBUG
+log_level: 20
 
 credentials:
   app_key: "INSERT ABC FITNESS APP KEY"
@@ -7,32 +7,19 @@ credentials:
   camio_api_token: "INSERT CAMIO DEV TOKEN"
 
 urls:
-  devices: "https://api.abcfinancial.com/rest/{club_id}/clubs/stations"
-  events: "https://api.abcfinancial.com/rest/{club_id}/clubs/checkins/details"
-  members: "https://api.abcfinancial.com/rest/{club_id}/members"
   pacs_server: "https://incoming.integrations.camio.com/pacs"
   skip_ssl_verification: false
 
 requests:
   devices:
-    polling_interval: 43200  # in seconds, how frequently to request station information via the ABC Fitness API. Defaults to every 12 hours
-
-  pacs:
-    backoff_multiplier: 2.0  # multiplier for increasing sleep between retries
-    backoff_start: 2.0  # initial seconds until retry, gets multiplied by backoff_multiplier after each attempt
-    backoff_limit: 3  # max number of retries
-
+    polling_interval: 30  # seconds between calls to fetch devices
   events:
-    streaming: false  # ABC Fitness API does not support streaming
-    count_reset_interval: 86400  # reset the events count every 24 hours
-    polling_interval: 900  # in seconds, how frequently to request checkin information via the ABC Fitness API. Defaults to every 12 hours but for testing is set here to 15 minutes
-    timezone_offset:  # Timezone offset for the timestamps of the events. Format is +/-HHMM. Examples: -0700, +0100. Does not account for daylight savings time, since the number is always added/subtracted from the UTC time. Default is None.
-    timezone_name: "UTC"  # Name of the timezone that the event timestamps are in. Uses pytz timezones. If timezone_offset is also passed, will use the offset over the timezone name. Should account for daylight savings. Examples: US/Central, US/Eastern, US/Pacific, Europe/Paris. Default is UTC.
+    polling_interval: 10  # seconds between calls to fetch events
+    count_reset_interval: 180
     get_member_info: true
-    page_size: 100
-
+    page_size: 2
   members:
-    page_size: 100
+    page_size: 2
 
 test_values:
   create_events_url: "https://api.abcfinancial.com/rest/{club_id}/members/checkins/{member_id}"

--- a/integrations/driver/helm/camio-abc-fitness/values.yaml
+++ b/integrations/driver/helm/camio-abc-fitness/values.yaml
@@ -32,7 +32,7 @@ requests:
     page_size: 100
 
 container:
-  image: camio-integration-driver-abc-fitness
+  image: us-central1-docker.pkg.dev/camiologger/public-containers/camio-integration-driver-abc-fitness:latest-linux-amd64
 
 # Note: Can supply no more than three nameservers
 dns:

--- a/integrations/driver/install_docker.sh
+++ b/integrations/driver/install_docker.sh
@@ -20,4 +20,5 @@ sudo apt-get update
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
 sudo groupadd docker
-sudo usermod -aG docker pi
+# You may need to give your current user access to run docker
+#sudo usermod -aG docker {{user}}


### PR DESCRIPTION
Changes include:
- Added more defaults to the Camio ABC Fitness driver schemas
   - Config files can now specify less fields
- Changes the docker compose and helm chart values to use the hosted driver images by default
   - A custom built docker image/helm chart can still be used, see the README for more details
- Updates to the README 
- Quick install script for powershell 