### PR TITLE
ABC Fitness Driver - Schema Default Values

### DIFF
--- a/integrations/driver/app/abc_fitness.py
+++ b/integrations/driver/app/abc_fitness.py
@@ -447,6 +447,39 @@ class TestABCFitnessDriver(TestBaseIntegrationDriver):
                                                                           task_names=task_names,
                                                                           member_id=self.member_id)
 
+    async def test_minimal_driver_config(self):
+        """
+        Test the driver schema taking the minimum required field.
+        """
+
+        # Currently, only the credential fields should be required
+        config = {
+            "credentials": {
+                "app_key": "1",
+                "app_id": "2",
+                "club_id": "3",
+                "camio_api_token": "4"
+            }
+        }
+
+        # Raises an error if any required fields are missing
+        driver_config = ABCFitnessIntegrationDriverConfig(**config)
+        print(f"Driver config: \n{driver_config}")
+        self.assertIsNotNone(driver_config)
+
+        # Assert default urls are populated
+        self.assertIsNotNone(driver_config.urls)
+        self.assertIsNotNone(driver_config.urls.devices)
+        self.assertIsNotNone(driver_config.urls.events)
+        self.assertIsNotNone(driver_config.urls.pacs_server)
+
+        # Assert default polling intervals are populated
+        self.assertIsNotNone(driver_config.requests)
+        self.assertIsNotNone(driver_config.requests.devices)
+        self.assertIsNotNone(driver_config.requests.devices.polling_interval)
+        self.assertIsNotNone(driver_config.requests.events)
+        self.assertIsNotNone(driver_config.requests.events.polling_interval)
+
     async def test_get_events(self):
         # Set last fetch time as now so that we only fetch the test events from now -> time of get_events
         self.driver.last_fetch_time = datetime.datetime.utcnow()

--- a/integrations/driver/app/abc_fitness_schemas.py
+++ b/integrations/driver/app/abc_fitness_schemas.py
@@ -308,6 +308,7 @@ class ABCFitnessMembersRequestConfig(BaseModel):
     """
     Config for calling the events members url. Include the number of members to request in one page.
     """
+
     page_size: int = Field(100, description="The number of members to request in one call to the ABCFitness API")
 
 
@@ -316,9 +317,12 @@ class ABCFitnessRequestConfigMap(BaseRequestConfigMap):
     Configs specific to the URL being called.
     """
 
-    devices: ABCFitnessDevicesRequestConfig = Field(description="Config for requests to the integration's devices URL")
-    events: ABCFitnessEventsRequestConfig = Field(description="Config for requests to the integration's events URL")
-    members: ABCFitnessMembersRequestConfig = Field(description="Config for requests to the integration's members URL")
+    devices: ABCFitnessDevicesRequestConfig = Field(ABCFitnessDevicesRequestConfig(),
+                                                    description="Config for requests to the integration's devices URL")
+    events: ABCFitnessEventsRequestConfig = Field(ABCFitnessEventsRequestConfig(),
+                                                  description="Config for requests to the integration's events URL")
+    members: ABCFitnessMembersRequestConfig = Field(ABCFitnessMembersRequestConfig(),
+                                                    description="Config for requests to the integration's members URL")
 
 
 class ABCFitnessIntegrationDriverConfig(BaseIntegrationDriverConfig, extra=Extra.allow):
@@ -328,6 +332,7 @@ class ABCFitnessIntegrationDriverConfig(BaseIntegrationDriverConfig, extra=Extra
     should go into one of these Pydantic models instead of in the code directly.
     """
 
-    urls: ABCFitnessUrls = Field(description="The urls to be called by the integration driver")
-    requests: ABCFitnessRequestConfigMap = Field(description="Configurations for calls to various urls, such as "
+    urls: ABCFitnessUrls = Field(ABCFitnessUrls(), description="The urls to be called by the integration driver")
+    requests: ABCFitnessRequestConfigMap = Field(ABCFitnessRequestConfigMap(),
+                                                 description="Configurations for calls to various urls, such as "
                                                              "polling intervals and backoff attempts")


### PR DESCRIPTION
Missing default values in the ABC Fitness driver schema caused an error in the docker version of the driver when using the updated config file containing only the credential fields.