### PR TITLE
ABC Fitness Driver - Remove Calls to Stations Endpoint

### DIFF
--- a/integrations/driver/ABCFitnessREADME.md
+++ b/integrations/driver/ABCFitnessREADME.md
@@ -90,7 +90,6 @@ need to contact ABC.
 | log_level | The base level of logs that will be printed in the driver container. 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERR0R), 50 (CRITICAL) | 10 (INFO logs and up) |
 | requests.events.polling_interval | How frequently to request the check in information from the ABC Fitness API. Defaults to every 12 hours. | 43200 (seconds) |
 | requests.events.get_member_info | If true, makes a request to the ABC Fitness API to fetch the member information for each checkin event. Enables Camio to send tailgating notifications to members by retrieving the member email. | true |
-| requests.devices.polling_interval | How frequently to request the station information from the ABC Fitness API. Defaults to every 12 hours. | 43200 (seconds) |
 
 ### Start the Docker Container
 
@@ -137,7 +136,6 @@ are all required in order for the driver to contact the ABC Fitness and Camio AP
 | log_level | The base level of logs that will be printed in the driver container. 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERR0R), 50 (CRITICAL) | 10 (INFO logs and up) |
 | requests.events.polling_interval | How frequently to request the check in information from the ABC Fitness API. Defaults to every 12 hours. | 43200 (seconds) |
 | requests.events.get_member_info | If true, makes a request to the ABC Fitness API to fetch the member information for each checkin event. Enables Camio to send tailgating notifications to members by retrieving the member email. | true |
-| requests.devices.polling_interval | How frequently to request the station information from the ABC Fitness API. Defaults to every 12 hours. | 43200 (seconds) |
 | container.image | The Camio ABC Fitness driver container image. Default to the amd-64 image. Can be changed to the arm64 image or to a custom image. | us-central1-docker.pkg.dev/camiologger/public-containers/camio-integration-driver-abc-fitness:latest-linux-amd64 |
 
 ### Install the Helm Chart
@@ -145,7 +143,7 @@ are all required in order for the driver to contact the ABC Fitness and Camio AP
 Run this command from the directory with your values.yaml file.
 
 ```
-helm install camio-abc-fitness oci://us-central1-docker.pkg.dev/camiologger/helm/camio-abc-fitness --version 1.0.0 -f values.yaml -n camio --create-namespace
+helm install camio-abc-fitness oci://us-central1-docker.pkg.dev/camiologger/helm/camio-abc-fitness --version 1.0.1 -f values.yaml -n camio --create-namespace
 ```
 
 ## Run the Driver Using Python [Not Recommended]

--- a/integrations/driver/app/abc_fitness_schemas.py
+++ b/integrations/driver/app/abc_fitness_schemas.py
@@ -125,6 +125,7 @@ class ABCFitnessEvent(BaseModel, extra=Extra.allow):
 
 class ABCFitnessDevice(BaseModel):
     """
+    DEPRECATED
     In ABC Fitness terminology, a station. Ex:
     {
         "stationId": "F84273CC22A44655AE78FC04F6A8CA30",
@@ -267,8 +268,8 @@ class ABCFitnessUrls(BaseUrls, extra=Extra.allow):
     Contains the full urls for each request type. Some urls are optional.
     """
 
-    devices: str = Field("https://api.abcfinancial.com/rest/{club_id}/clubs/stations",
-                         description="Url to call to get the user's ABC Fitness stations")
+    devices: str = Field(None,
+                         description="DEPRECATED. Used to be https://api.abcfinancial.com/rest/{club_id}/clubs/stations")
     events: str = Field("https://api.abcfinancial.com/rest/{club_id}/clubs/checkins/details",
                         description="Url to call to get the user's ABC Fitness checkin events")
     pacs_server: str = Field("https://incoming.integrations.camio.com/pacs",
@@ -297,6 +298,7 @@ class ABCFitnessEventsRequestConfig(BaseEventsRequestConfig):
 
 class ABCFitnessDevicesRequestConfig(BaseDevicesRequestConfig):
     """
+    DEPRECATED
     Config for calling the events (checkins) url. Include the number of checkins to request in one page.
     """
 
@@ -317,8 +319,8 @@ class ABCFitnessRequestConfigMap(BaseRequestConfigMap):
     Configs specific to the URL being called.
     """
 
-    devices: ABCFitnessDevicesRequestConfig = Field(ABCFitnessDevicesRequestConfig(),
-                                                    description="Config for requests to the integration's devices URL")
+    # devices: ABCFitnessDevicesRequestConfig = Field(ABCFitnessDevicesRequestConfig(),
+    #                                                 description="DEPRECTAED. Config for requests to the integration's devices URL")
     events: ABCFitnessEventsRequestConfig = Field(ABCFitnessEventsRequestConfig(),
                                                   description="Config for requests to the integration's events URL")
     members: ABCFitnessMembersRequestConfig = Field(ABCFitnessMembersRequestConfig(),

--- a/integrations/driver/configs/test/abc_fitness_config.yaml
+++ b/integrations/driver/configs/test/abc_fitness_config.yaml
@@ -12,7 +12,7 @@ urls:
 
 requests:
   devices:
-    polling_interval: 30  # seconds between calls to fetch devices
+    polling_interval: 30  # seconds between calls to fetch devices, NOTE: This is important for testing because it determines when the event task will yield for the devices task. Without this, the test_run unittest may run for 12 hours.
   events:
     polling_interval: 10  # seconds between calls to fetch events
     count_reset_interval: 180

--- a/integrations/driver/helm/camio-abc-fitness/Chart.yaml
+++ b/integrations/driver/helm/camio-abc-fitness/Chart.yaml
@@ -1,6 +1,6 @@
 name: camio-abc-fitness
 description: A generated Helm Chart for helm/camio-abc-fitness from Skippbox Kompose
-version: 1.0.0
+version: 1.0.1
 apiVersion: v1
 keywords:
   - camio-abc-fitness

--- a/integrations/driver/helm/camio-abc-fitness/templates/driver-cm0-configmap.yaml
+++ b/integrations/driver/helm/camio-abc-fitness/templates/driver-cm0-configmap.yaml
@@ -11,15 +11,12 @@ data:
       camio_api_token: {{ .Values.credentials.camio_api_token | quote }}
 
     urls:
-      devices: "https://api.abcfinancial.com/rest/{club_id}/clubs/stations"
       events: "https://api.abcfinancial.com/rest/{club_id}/clubs/checkins/details"
       members: "https://api.abcfinancial.com/rest/{club_id}/members"
       pacs_server: {{ if .Values.urls.pacs_server }}{{ .Values.urls.pacs_server | quote }}{{ else }}"https://{{ .Values.urls.camio_domain }}/pacs"{{ end }}
       skip_ssl_verification: {{ .Values.urls.skip_ssl_verification }}
 
     requests:
-      devices:
-        polling_interval: {{ .Values.requests.devices.polling_interval | default 43200 }}
       pacs:
         backoff_multiplier:  {{ .Values.requests.pacs.backoff_multiplier }}
         backoff_start: {{ .Values.requests.pacs.backoff_start }}

--- a/integrations/driver/helm/camio-abc-fitness/values.yaml
+++ b/integrations/driver/helm/camio-abc-fitness/values.yaml
@@ -11,8 +11,6 @@ urls:
   skip_ssl_verification: false
 
 requests:
-  devices:
-    polling_interval: 43200  # in seconds, how frequently to request station information via the ABC Fitness API. Defaults to every 12 hours
 
   pacs:
     backoff_multiplier: 2.0  # multiplier for increasing sleep between retries


### PR DESCRIPTION
It was determined that the stations endpoint, [/{clubNumber}/clubs/stations](https://abcfinancial.3scale.net/docs/clubs#!/Clubs/getStationsUsingGET), does not return the same stations that are named in the checkins response, [/{clubNumber}/clubs/checkins/details](https://abcfinancial.3scale.net/docs/clubs#!/Clubs/getCheckinDetailsUsingGET). For now devices fetching and forwarding has been removed from the ABC Fitness Driver. Stations will need to be mapped by manually entering station names on https://camio.com/settings/integrations/pacs.